### PR TITLE
Devel

### DIFF
--- a/pgsnap/lib/getopt.php
+++ b/pgsnap/lib/getopt.php
@@ -37,6 +37,7 @@ $g_nopassword = false;
 $g_withoutsysobjects = false;
 $g_alldatabases = false;
 $g_deleteifexists = false;
+$g_withollastlog = false;
 $g_witholdlibpq = false;
 $outputdir = '';
 $outputdirmode = 700;
@@ -91,6 +92,9 @@ for ($i = 1; $i < $_SERVER["argc"]; $i++) {
     case "-S":
     case "--without-sysobjects":
       $g_withoutsysobjects = true;
+      break;
+    case "--without-lastlog":
+      $g_withoutlastlog = true;
       break;
     case "-a":
     case "--all":

--- a/pgsnap/lib/reports.php
+++ b/pgsnap/lib/reports.php
@@ -186,6 +186,7 @@ if ($g_files['recovery.conf']) {
   include 'lib/contents_recovery.php';
 }
 if ($g_superuser && $g_version > '74'
+   && (! $g_withoutlastlog)
    && (!strcmp($g_settings['log_destination'], 'stderr')
          || !strcmp($g_settings['log_destination'], 'csvlog'))
    && ((array_key_exists('redirect_stderr', $g_settings)

--- a/pgsnap/lib/roles.php
+++ b/pgsnap/lib/roles.php
@@ -26,8 +26,12 @@ $query = "SELECT rolname,
   rolsuper,
   rolinherit,
   rolcreaterole,
-  rolcreatedb,
-  rolcatupdate,
+  rolcreatedb,";
+if ($g_version < 95) {
+  $query .= "
+  rolcatupdate,";
+}
+$query .= "
   rolcanlogin,
   rolconnlimit,";
 if ($g_version > 90) {
@@ -91,8 +95,12 @@ $buffer .= tr().'
   <td>'.$image[$row['rolsuper']].'</td>
   <td>'.$image[$row['rolinherit']].'</td>
   <td>'.$image[$row['rolcreaterole']].'</td>
-  <td>'.$image[$row['rolcreatedb']].'</td>
-  <td>'.$image[$row['rolcatupdate']].'</td>
+  <td>'.$image[$row['rolcreatedb']].'</td>';
+if ($g_version < 95) {
+$buffer .= '
+  <td>'.$image[$row['rolcatupdate']].'</td>';
+}
+$buffer .= '
   <td>'.$image[$row['rolcanlogin']].'</td>';
 if ($g_version > 90) {
 $buffer .= '


### PR DESCRIPTION
- fix compatibility with pg 9.5+
- add a --without-lastlog option, because retrieving the last log can easily fail (or just be painful) if the file is too big.
